### PR TITLE
DerpSpace: localize: Add Chinease (Simpified) translate

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--  Copyright (C) 2014-2016 The Dirty Unicorns Project
+      Copyright (C) 2016 AospExtended ROM Project
+      Copyright (C) 2022 DerpFest
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ -->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- General app strings -->
+    <string name="derpspace_title" translatable="false">DerpSpace</string>
+    <string name="add">添加</string>
+    <string name="advanced">高级</string>
+    <string name="cancel">取消</string>
+    <string name="default_text">默认</string>
+    <string name="dlg_ok">确定</string>
+    <string name="attention">请注意</string>
+    <string name="loading">加载中\u2026</string>
+    <string name="reset">重置</string>
+    <string name="reset_colors">重置颜色</string>
+    <string name="reset_android">Android</string>
+    <string name="text_title">文本</string>
+    <string name="icon_title">图标</string>
+    <string name="color_title">颜色</string>
+    <string name="colors_title">颜色</string>
+
+    <!-- DerpSpace categories -->
+    <string name="icons_category">图标</string>
+    <string name="status_bar_category">状态栏</string>
+    <string name="notifications_panel_category">快速设置面板</string>
+    <string name="system_category">系统</string>
+    <string name="lockscreen_category">锁屏</string>
+    <string name="udfps_category">屏下指纹</string>
+    <string name="listview">列表视图</string>
+
+    <!-- Frags -->
+    <!-- General Tweaks -->
+    <string name="general_tweaks_title">常规设置</string>
+
+    <!-- Lockscreen UI -->
+    <string name="lockscreen_ui_title">锁屏界面</string>
+
+    <!-- Lockscreen general category -->
+    <string name="general_category">常规</string>
+
+    <!-- Lockscreen charging category -->
+    <string name="charging_category">充电</string>
+
+    <!-- Quicksettings media category -->
+    <string name="media_category">多媒体播放器</string>
+
+    <!-- Network Traffic -->
+    <string name="traffic_title">网速显示</string>
+
+    <!-- Misc DerpSpace -->
+    <string name="misc_derpspace_title">杂项</string>
+
+    <!-- Notifications -->
+    <string name="notifications_title">通知</string>
+
+    <!-- Quick Settings -->
+    <string name="quick_settings_title">快速设置</string>
+
+    <!-- Status bar clock and date options -->
+    <string name="status_bar_clock_title">时钟 &amp; 日期设置</string>
+
+    <!-- Quick Settings brightness slider -->
+    <string name="qs_brightness_slider_category">亮度调节条</string>
+
+    <!-- Quick Settings footer category -->
+    <string name="footer_category">脚注</string>
+
+    <!-- Statusbar Iten -->
+    <string name="statusbar_items_category">状态栏图标</string>
+
+    <!-- Customisation -->
+    <string name="customisation_title">自定义</string>
+
+    <!-- Battery -->
+    <string name="battery_title">电量显示</string>
+
+   <!-- Battery Settings -->
+    <string name="battery_settings_title">电量显示</string>
+
+    <!-- Battery Styles -->
+    <string name="battery_style_category_title">电量显示风格</string>
+    <string name="battery_percent_title">电量百分比</string>
+
+    <!-- App info dialog -->
+    <string name="derpspace_dialog_title">让我们帮助你！</string>
+    <string name="derpspace_dialog_message">如果您发现了这些设置的 bug , 请在 Telegram 群组中告知我们. 您提出的 bug 报告中应包含以下内容:\n\n1. logcat 或 last_kmsg\n2. 内核和使用的模块\n3. 有用的信息\n\n如果您的报告中信息不完整, 您发现的 bug 可能很难修复.</string>
+    <string name="derpspace_dialog_toast">请熟读并背诵全文！</string>
+    <string name="artwork_media_fade_level_summary">淡出淡入式媒体封面</string>
+
+    <!-- QuickSettings haptic feedback -->
+    <string name="qs_tile_vibration_title">振动</string>
+    <string name="quick_settings_vibrate_title">触摸时振动</string>
+    <string name="quick_settings_vibrate_summary">触摸 QS 磁贴时振动</string>
+    <string name="quick_settings_vibrate_duration_title">振动持续时长</string>
+    <string name="quick_settings_vibrate_duration_summary">振动应持续多长时间(ms)</string>
+
+    <!-- Tiles animation style  -->
+    <string name="qs_tile_animation_title">动画</string>
+    <string name="qs_tile_animation_style_title">动画样式</string>
+    <string name="qs_tile_animation_duration_title">动画持续时长</string>
+    <string name="qs_tile_animation_interpolator_title">磁贴动画插值器</string>
+    <string name="qs_tile_animation_style_off">无动画</string>
+    <string name="qs_tile_animation_style_flip">翻转</string>
+    <string name="qs_tile_animation_style_rotate">旋转</string>
+    <string name="qs_tile_animation_duration_low">较慢</string>
+    <string name="qs_tile_animation_duration_default">默认</string>
+    <string name="qs_tile_animation_duration_fast">较快</string>
+    <string name="qs_tile_animation_interpolator_linearInterpolator">线性式</string>
+    <string name="qs_tile_animation_interpolator_accelerateInterpolator">加速式</string>
+    <string name="qs_tile_animation_interpolator_decelerateInterpolator">减速式</string>
+    <string name="qs_tile_animation_interpolator_accelerateDecelerateInterpolator">先加速后减速</string>
+    <string name="qs_tile_animation_interpolator_bounceInterpolator">弹跳式</string>
+    <string name="qs_tile_animation_interpolator_overshootInterpolator">前摇惯性式</string>
+    <string name="qs_tile_animation_interpolator_anticipateInterpolator">后摇惯性式</string>
+    <string name="qs_tile_animation_interpolator_anticipateOvershootInterpolator">前后摇惯性式</string>
+    <string name="qs_set_animation_style">%1$s</string>
+    <string name="qs_set_animation_duration">%1$s</string>
+    <string name="qs_set_animation_interpolator">%1$s</string>
+
+    <!-- 4G icon -->
+    <string name="show_fourg_icon_title">4G 图标</string>
+    <string name="show_fourg_icon_summary">以 4G 信号图标取代显示 LTE 文本</string>
+
+    <!-- Data disabled icon -->
+    <string name="data_disabled_icon_title">显示数据网络关闭叹号</string>
+    <string name="data_disabled_icon_summary">当数据网络关闭时在信号图标上显示一个叹号</string>
+
+    <!-- QS footer warnings -->
+    <string name="qs_footer_warnings_title">快速设置面板脚注</string>
+    <string name="qs_footer_warnings_summary">当网络被其他 APP 或者 VPN 监控时在快速面板的底部显示警告</string>
+
+    <!-- Old mobile type icons -->
+    <string name="use_old_mobiletype_title">信号类型显示</string>
+    <string name="use_old_mobiletype_summary">在移动信号指示器的上方显示信号类型</string>
+
+    <!-- Lockscreen battery info indicator  -->
+    <string name="lockscreen_battery_info_title">锁屏充电信息</string>
+    <string name="lockscreen_battery_info_summary">在锁屏时显示充电电流, 电压, 功率和电池温度</string>
+
+    <!-- Tiles on secure keyguard -->
+    <string name="use_tiles_on_secure_keyguard_title">使用敏感磁贴时要求解锁</string>
+    <string name="use_tiles_on_secure_keyguard_summary">当试图在锁屏界面使用功能敏感的快速设置磁贴时要求解锁</string>
+
+    <!-- QS footer text -->
+    <string name="qs_footer_text_show_title">显示快速设置脚注</string>
+    <string name="qs_footer_text_string_title">自定义脚注文本</string>
+    <string name="qs_footer_text_string_summary">置空以显示默认的 #StayDerped</string>
+
+    <!-- Notifications general category -->
+    <string name="notifications_general_category_title">常规</string>
+
+    <!-- Notification count -->
+    <string name="status_bar_notif_count_title">通知计数</string>
+    <string name="status_bar_notif_count_summary">显示待办通知的数量</string>
+
+    <!-- Units -->
+    <string name="unit_seconds">s</string>
+    <string name="unit_milliseconds">ms</string>
+    <string name="unit_pixels">dp</string>
+
+    <!-- [CHAR_LIMIT=NONE] Developer Settings: Title of the settings category for theme overlays. -->
+    <string name="theme_customization_category">主题设置</string>
+    <!-- [CHAR_LIMIT=NONE] Developer Settings: Title of the setting which enables overlays to customize headline and body fonts. -->
+    <string name="theme_customization_font_title">标题栏 / 主体字体</string>
+    <string name="theme_customization_font_summary">设定系统字体样式</string>
+    <!-- [CHAR_LIMIT=NONE] Developer Settings: Title of the setting which enables overlays to customize the adaptive icon shape (e.g. launcher and quick settings icons). -->
+    <string name="theme_customization_icon_shape_title">图标形状</string>
+    <string name="theme_customization_icon_shape_summary">设定系统默认图标形状</string>
+    <!-- [CHAR_LIMIT=NONE] Developer Settings: Title of the setting which enables overlays to customize the system wide icon pack. -->
+    <string name="theme_customization_icon_pack_title">图标包</string>
+    <string name="theme_customization_icon_pack_summary">设定自定义图标包</string>
+
+    <!-- [CHAR_LIMIT=NONE] Developer Settings: Label for the option that turns off customizations for a given category.-->
+    <string name="theme_customization_device_default">设备默认</string>
+
+    <!-- Custom Wi-Fi bar icons -->
+    <string name="theme_customization_wifi_icon_title">Wifi图标</string>
+    <string name="theme_customization_wifi_icon_summary">设置 WIFI 图标风格</string>
+
+    <!-- Custom Signal bar icons -->
+    <string name="theme_customization_signal_icon_title">信号图标</string>
+    <string name="theme_customization_signal_icon_summary">设置信号图标风格</string>
+
+    <!-- Black theme -->
+    <string name="system_black_theme_title">使用纯黑风格</string>
+    <string name="system_black_theme_summary">强制使用纯黑风格的主题</string>
+
+    <!-- UI styles -->
+    <string name="theme_customization_ui_style_title">UI 样式</string>
+    <string name="theme_customization_ui_style_summary">为您的 UI 设置自定义样式</string>
+
+    <!-- Applications fragment -->
+    <string name="search">搜索</string>
+    <string name="search_apps">搜索应用</string>
+
+    <!-- reTicker -->
+    <string name="reticker_category" translatable="false">reTicker精简横幅通知</string>
+    <string name="reticker_title">reTicker</string>
+    <string name="reticker_summary">将传统的大块横幅通知替换为重新设计的 reTicker 精简横幅 \n</string>
+    <string name="reticker_colored_title">使用 APP 颜色填充横幅背景</string>
+    <string name="reticker_colored_summary">使用发出通知的 APP 的主色调填充 reTicker 横幅的背景</string>
+    <string name="reticker_landscape_only_title">仅横屏时启用</string>
+    <string name="reticker_landscape_only_summary">只在设备处于横屏模式下时启用 reTicker 横幅</string>
+
+    <!-- Network traffic -->
+    <string name="network_traffic_title">网速显示</string>
+    <string name="network_traffic_summary">启用或关闭状态栏网速显示</string>
+    <string name="network_traffic_state_title">启用 "网速显示"</string>
+    <string name="network_options_title">选项</string>
+    <string name="network_traffic_autohide_title">当网络不活跃时隐藏网速显示</string>
+    <string name="network_traffic_autohide_summary">当网速低于 1 KB/s 时隐藏网速显示</string>
+
+    <!-- Media art -->
+    <string name="lockscreen_media_art_options_title">媒体封面</string>
+    <string name="media_art_title">媒体封面</string>
+    <string name="media_art_summary">当可用时显示媒体封面</string>
+
+    <!-- Lock screen cover art -->
+    <string name="lockscreen_media_blur_title">媒体封面模糊等级</string>
+
+    <!-- Clock position -->
+    <string name="status_bar_clock_position_center">居中</string>
+    <string name="status_bar_clock_position_left">左对齐</string>
+    <string name="status_bar_clock_position_right">右对齐</string>
+    <string name="status_bar_clock_position_title">时钟位置</string>
+
+    <!-- Clock AM/PM -->
+    <string name="status_bar_am_pm_hidden">隐藏</string>
+    <string name="status_bar_am_pm_normal">正常</string>
+    <string name="status_bar_am_pm_small">较小</string>
+    <string name="status_bar_am_pm_title">时钟 AM/PM 样式</string>
+    <string name="status_bar_am_pm_unavailable">使用 24 小时制时钟</string>
+
+    <!-- Clock show seconds -->
+    <string name="status_bar_clock_show_seconds_title">时钟显秒</string>
+    <string name="status_bar_clock_show_seconds_desc">状态栏时钟显示时, 分, 秒</string>
+
+    <!-- Battery style and percentage -->
+    <string name="status_bar_battery_style_circle">圆圈式</string>
+    <string name="status_bar_battery_style_icon_portrait">纵向图标</string>
+    <string name="status_bar_battery_style_text">纯文本</string>
+    <string name="status_bar_battery_style_title">电量图标风格</string>
+    <string name="status_bar_battery_percentage_hidden">隐藏</string>
+    <string name="status_bar_battery_percentage_text_inside">图标内</string>
+    <string name="status_bar_battery_percentage_text_next">图标旁</string>
+    <string name="status_bar_battery_percentage_title">电量百分比</string>
+
+    <!-- Brightness slider -->
+    <string name="qqs_show_brightness_title">在通知面板中显示亮度调节条</string>
+    <string name="brightness_slider_position_title">亮度调节条位置</string>
+    <string name="top">顶部</string>
+    <string name="bottom">底部</string>
+    <string name="show_auto_brightness_button_title">显示"自动亮度"按钮</string>
+
+    <!-- Pulse -->
+    <string name="ambient_light_category">边缘亮起</string>
+    <string name="keywords_pulse_ambient_light_display">通知, 边缘, 亮起, 颜色</string>
+    <string name="pulse_ambient_light_text">当收到通知时点亮屏幕两侧边缘并作脉冲状，有助于您在手机熄屏状态时更易确认是否有新通知</string>
+    <string name="pulse_ambient_light_enable">启用边缘亮起</string>
+    <string name="pulse_ambient_light_title">边缘亮起</string>
+    <string name="pulse_ambient_light_summary">收到通知时点亮屏幕两侧边缘并作脉冲状</string>
+    <string name="ambient_notification_light_accent_title">系统颜色风格</string>
+    <string name="ambient_notification_light_color_automatic_title">通知颜色风格</string>
+    <string name="pulse_ambient_light_color">脉冲条颜色使用: </string>
+
+    <!-- QS tiles layout -->
+    <string name="qs_tile_layout_title">快速设置(QS)磁贴设置</string>
+    <string name="qs_tile_layout_summary">自定义 QS 磁贴布局</string>
+    <string name="qs_tiles_layout_category">磁贴布局</string>
+    <string name="qs_rows_portrait_title">行数 ( QS 面板纵向)</string>
+    <string name="qqs_rows_portrait_title">行数 (通知面板纵向)</string>
+    <string name="qs_columns_portrait_title">列数 (纵向)</string>
+    <string name="qs_apply_change_button_title">应用变更</string>
+    <string name="qs_apply_change_failed">变更应用失败</string>
+    <string name="qs_tile_hide_label_title">隐藏标签</string>
+    <string name="qs_tile_hide_label_summary">仅显示 QS 磁贴图标</string>
+    <string name="qs_tile_vertical_layout_title">纵向布局</string>
+    <string name="qs_tile_vertical_layout_summary">启用 QS 磁贴纵向布局</string>
+
+    <!-- Statusbar lyric -->
+    <string name="status_bar_lyric_title">状态栏歌词</string>
+    <string name="status_bar_lyric_summary">在状态栏中显示歌词(需应用程序支持)</string>
+    <string name="status_bar_show_lyric_title">显示状态栏歌词</string>
+
+    <!-- Statusbar logo -->
+    <string name="status_bar_logo_category_title">Logo</string>
+    <string name="status_bar_logo_title">Logo</string>
+    <string name="status_bar_logo_summary">在状态栏中显示一个 Logo</string>
+    <string name="status_bar_logo_position_title">位置</string>
+    <string name="status_bar_logo_position_summary">选择 logo 的显示位置</string>
+    <string name="status_bar_logo_position_right">右对齐</string>
+    <string name="status_bar_logo_position_left">左对齐</string>
+    <string name="status_bar_logo_style_title">样式</string>
+    <string name="status_bar_logo_style_derp">DerpFest</string>
+    <string name="status_bar_logo_style_derp_alt">DerpFest三角</string>
+    <string name="status_bar_logo_style_adidas">阿迪达斯</string>
+    <string name="status_bar_logo_style_airjordan">Air Jordan(AJ)</string>
+    <string name="status_bar_logo_style_apple">苹果</string>
+    <string name="status_bar_logo_style_avengers">复仇者联盟</string>
+    <string name="status_bar_logo_style_batman">蝙蝠侠</string>
+    <string name="status_bar_logo_style_batman_tdk">蝙蝠侠:黑暗骑士</string>
+    <string name="status_bar_logo_style_beats">Beats</string>
+    <string name="status_bar_logo_style_biohazard">生物危害警示</string>
+    <string name="status_bar_logo_style_blackberry">黑莓</string>
+    <string name="status_bar_logo_style_cannabis">Cannabis</string>
+    <string name="status_bar_logo_style_fire">火焰</string>
+    <string name="status_bar_logo_style_nike">耐克(Nike)</string>
+    <string name="status_bar_logo_style_pac_man">吃豆人</string>
+    <string name="status_bar_logo_style_puma">彪马(Puma)</string>
+    <string name="status_bar_logo_style_rog">ROG 玩家国度</string>
+    <string name="status_bar_logo_style_superman">Superman</string>
+    <string name="status_bar_logo_style_windows">Windows</string>
+    <string name="status_bar_logo_style_xbox">XBOX</string>
+
+    <!-- Pulse music visualizer -->
+    <string name="pulse_help_policy_notice_title">关于律动脉冲</string>
+    <string name="pulse_help_policy_notice_summary">律动脉冲是一个非常好用的音频可视化器</string>
+    <string name="pulse_settings">律动脉冲</string>
+    <string name="pulse_settings_summary">适用于导航栏, 锁屏, 熄屏显示的音频可视化器</string>
+    <string name="show_navbar_pulse_title">导航栏律动</string>
+    <string name="show_navbar_pulse_summary">适用于导航栏的律动脉冲</string>
+    <string name="show_lockscreen_pulse_title">锁屏律动</string>
+    <string name="show_lockscreen_pulse_summary">适用于锁屏的律动脉冲</string>
+    <string name="show_ambient_pulse_title">熄屏显示律动</string>
+    <string name="show_ambient_pulse_summary">适用于熄屏显示的律动脉冲</string>
+    <string name="pulse_render_mode_title">渲染模式</string>
+    <string name="pulse_render_mode_fading_bars">淡出淡入方块式</string>
+    <string name="pulse_render_mode_solid_lines">线条式</string>
+    <string name="pulse_legacy_mode_advanced_category">方块式设置</string>
+    <string name="pulse_custom_fudge_factor">敏感度</string>
+    <string name="pulse_lavalamp_speed_title">颜色切换速度</string>
+    <string name="pulse_solid_units_count">线条数量</string>
+    <string name="pulse_solid_units_opacity">线条透明度</string>
+    <string name="pulse_solid_dimen_category">线条式设置</string>
+    <string name="pulse_color_mode_title">颜色</string>
+    <string name="pulse_color_accent">风格</string>
+    <string name="pulse_color_custom">自定义</string>
+    <string name="pulse_color_lava_lamp">五彩斑斓</string>
+    <string name="pulse_color_auto">自动</string>
+    <string name="pulse_color_user_title">拾色器</string>
+    <string name="pulse_smoothing_enabled_title">启用平滑动画</string>
+    <string name="pulse_smoothing_enabled_summary">使线条动画更加平滑</string>
+    <string name="pulse_custom_dimen">线条宽度</string>
+    <string name="pulse_custom_div">线条间距</string>
+    <string name="pulse_filled_block_size">方块大小</string>
+    <string name="pulse_empty_block_size">方块间距</string>
+    <string name="pulse_solid_units_rounded_title">线条圆角</string>
+    <string name="pulse_solid_units_rounded_summary">使用圆角化的线条</string>
+
+    <!-- Udfps animations -->
+    <string name="udfps_recog_animation">使用屏下指纹动画</string>
+    <string name="udfps_recog_animation_summary">当识别您的指纹时显示识别动画</string>
+    <string name="udfps_recog_animation_effect_title">自定义屏下指纹动画</string>
+    <string name="udfps_recog_animation_effect_summary">选择动画特效</string>
+
+    <!-- Udfps icon picker -->
+    <string name="udfps_icon_picker_title">选择屏下指纹图标</string>
+    <string name="udfps_icon_picker_summary">选择并应用您心仪的屏下指纹图标</string>
+
+    <!-- Lockscreen charge temperature unit -->
+    <string name="lockscreen_charge_temp_unit_title">温度单位</string>
+    <string name="lockscreen_charge_temp_unit_farhenheit">华氏温标</string>
+    <string name="lockscreen_charge_temp_unit_celsius">摄氏温标</string>
+
+    <!-- Material dismiss all button for notifications -->
+    <string name="notification_material_dismiss_title">"清除所有通知"按钮</string>
+    <string name="notification_material_dismiss_summary">使用 Material You 风格的 "清除所有通知" 按钮取代原本的文本</string>
+    <string name="notification_material_dismiss_style_title">按钮样式</string>
+    <string name="notification_material_dismiss_bgstyle_title">按钮背景</string>
+
+    <!-- Bluetooth status -->
+    <string name="bluetooth_battery_title">蓝牙设备电量显示</string>
+    <string name="bluetooth_battery_summary">在可用时显示已连接的蓝牙设备电量</string>
+
+    <!-- Clock auto hide -->
+    <string name="status_bar_clock_auto_hide_title">自动隐藏</string>
+    <string name="status_bar_clock_auto_hide_summary">当启动器时钟可见时自动隐藏状态栏时钟</string>
+
+    <!-- Display Settings: Title of the setting which toggles wallpaper zooming effects on interraction -->
+    <string name="wallpaper_zoom_effect_title">壁纸缩放特效</string>
+    <!-- Display Settings: Subtitle of the setting which toggles wallpaper zooming effects on interraction -->
+    <string name="wallpaper_zoom_effect_summary">放大壁纸以实现壁纸景深缩放特效, 可能影响壁纸质量</string>
+
+    <!-- Squiggle animation -->
+    <string name="show_squiggle_animation_title">显示曲线进度条</string>
+    <string name="show_squiggle_animation_summary">在媒体播放面板中显示曲线样式的进度条\n该项变更后需要切换音乐/暂停音乐/快进以应用更改</string>
+
+    <!-- Ambient battery bar settings -->
+    <string name="ambient_ui">熄屏显示</string>
+    <string name="ambient_battery_settings_title">电池栏</string>
+    <string name="ambient_battery_settings_summary">熄屏时显示电池栏</string>
+    <string name="keyguard_show_battery_title">充电时显示电池栏</string>
+    <string name="keyguard_show_battery_summary">熄屏充电时显示电池栏</string>
+    <string name="keyguard_show_battery_always_title">总是显示电池栏</string>
+    <string name="keyguard_show_battery_always_summary">熄屏时总是显示电池栏</string>
+
+    <!-- Pulse Gravity and mirror options -->
+    <string name="pulse_custom_gravity_title">重力方向</string>
+    <string name="pulse_custom_gravity_bottom">向下</string>
+    <string name="pulse_custom_gravity_top">向上</string>
+    <string name="pulse_custom_gravity_center">中心</string>
+    <string name="visualizer_center_mirrored_title">纵轴镜像</string>
+    <string name="visualizer_center_mirrored_summary">将律动设置为纵轴对称模式</string>
+    <string name="pulse_vertical_mirror_title">横轴镜像</string>
+    <string name="pulse_vertical_mirror_summary">将律动设置为横轴对称模式</string>
+
+    <!-- Ripple Effect on lockscreen -->
+    <string name="disable_fingerprint_ripple_effect_title">关闭水波纹特效</string>
+    <string name="disable_fingerprint_ripple_effect_summary">使用指纹解锁时不使用水波纹解锁动画</string>
+
+    <!-- Charging animation -->
+    <string name="charging_animation_title">充电动画</string>
+    <string name="charging_animation_summary">当充电器插入时显示动画</string>
+
+    <!-- Statusbar Clock background chip -->
+    <string name="statusbar_clock_chip_title">背景条</string>
+    <string name="statusbar_clock_chip_summary">显示 Material You 风格化的状态栏时钟背景条</string>
+
+    <!-- Hide statusbar on lockscreen -->
+    <string name="lockscreen_hide_status_bar_title">隐藏状态栏</string>
+    <string name="lockscreen_hide_status_bar_summary">该项启动时，锁屏界面的状态栏将被自动隐藏</string>
+
+    <!-- Android P animation style -->
+    <string name="pie_animation_style_title">Android P 动画样式</string>
+    <string name="pie_animation_style_summary">启用Android P \"默认\" 动画</string>
+
+    <!-- Parallel space -->
+    <string name="laboratory_parallel_space_title">平行空间</string>
+    <string name="laboratory_parallel_space_summary">应用多开</string>
+
+</resources>


### PR DESCRIPTION
### DerpSpace 中文翻译注记
1. "Quick Settings" 译作 "快速设置"
2. 汉语名词不具备传统意义上的单复数形式变化，因此如"color, colors" 和 "icon, icons" 等词语不做区分统一翻译
3. "Under-Display FingerPrint Sensor" 译作"屏下指纹", 经考证国内多数 数码社区使用该说法, 故由此翻译以贴合国人习惯
4. "Network Traffic" 译作网速显示, 没有直译
5. 经释义查证, "vibrate/vibration" 应译为"振动"而非"震动"
6. "tile" 原义为 "瓷砖/瓦片", 巨硬于 2014 年发布的 Windows 8 操作系统 中的开始菜单样式 "tile" 被译作 "磁贴", 本次采用这里的翻译
7. "accelerate/decelerate" 动画插值器为贴合语境译作 "加速式/减速式"
8. "overshoot" 原义为 "过冲, 超出, 突破", 这里为贴合动画插值器语境结合 该插值器的实际作用, 译作 "前摇惯性式" 动画插值器
9. "anticipate" 同理译作 "后摇惯性式" 动画插值器
10. "QS Footer" 译作 "QS 面板脚注"
11. "reTicker" 保留不作翻译并加入 "精简横幅通知" 中文注释
12. "logo" 保留不作翻译
13. "Pulse" 译作律动脉冲
14. "Parallel Space" 译作平行空间并加入中文注释 "应用多开"