### PR TITLE
DerpSpace: Reset props for status bar lyric

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -298,6 +298,9 @@
     <string name="status_bar_lyric_title">状态栏歌词</string>
     <string name="status_bar_lyric_summary">在状态栏中显示歌词(需应用程序支持)</string>
     <string name="status_bar_show_lyric_title">显示状态栏歌词</string>
+    <string name="status_bar_lyric_options_title">选项</string>
+    <string name="disguise_props_for_music_app_title">对音乐应用伪装机型</string>
+    <string name="disguise_props_for_music_app_summary">对一些音乐应用伪装机型以正确启用状态栏歌词. 启用该设置后需要重启音乐应用</string>
 
     <!-- Statusbar logo -->
     <string name="status_bar_logo_category_title">Logo</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -258,6 +258,9 @@
     <string name="status_bar_lyric_title">Status bar lyric</string>
     <string name="status_bar_lyric_summary">Show lyric in status bar (need app support)</string>
     <string name="status_bar_show_lyric_title">Enable status bar lyric</string>
+    <string name="status_bar_lyric_options_title">Options</string>
+    <string name="disguise_props_for_music_app_title">Disguise device for music apps</string>
+    <string name="disguise_props_for_music_app_summary">Disguise device in some music applications for support status bar lyric. After changing this toggle, you have to restart applications for the change to take effect.</string>
 
     <!-- Statusbar logo -->
     <string name="status_bar_logo_category_title">Logo</string>
@@ -528,4 +531,6 @@
 
     <!-- QS Header -->
     <string name="qs_header_image_title">QS Header Image</string>
+
+    
 </resources>

--- a/res/xml/status_bar_lyric_settings.xml
+++ b/res/xml/status_bar_lyric_settings.xml
@@ -23,4 +23,15 @@
         android:key="status_bar_show_lyric"
         android:title="@string/status_bar_show_lyric_title"
         android:defaultValue="false"/>
+
+    <PreferenceCategory
+        android:title="@string/status_bar_lyric_options_title">
+
+        <org.derpfest.support.preferences.SystemPropertySwitchPreference
+            android:key="persist.sys.disguise_props_for_music_app"
+            android:title="@string/disguise_props_for_music_app_title"
+            android:summary="@string/disguise_props_for_music_app_summary"
+            android:dependency="status_bar_show_lyric"
+            android:defaultValue="false"/>
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
- Reset props to Meizu in some apps to use status bar lyric

Some Chinese music apps (such as NetEase Cloud Music) require a specific phone to enable status bar lyrics correctly. We need to spoof device props to them. Pick this workaround from Project Kaleidoscope ( sadly discontinued ) to make it work.

Tests: Open Netease Cloud Music and enable status bar lyric, it works fine.