### PR TITLE
DerpSpace: Reduce default landscape QS column amount

### DIFF
--- a/res/xml/quick_settings.xml
+++ b/res/xml/quick_settings.xml
@@ -90,7 +90,7 @@
          android:max="6"
          settings:min="2"
          settings:interval="1"
-         android:defaultValue="4" />
+         android:defaultValue="2" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
* Since we're enabling the Split notification shade, using 4 will cut off the qs title