### PR TITLE
Add option to toggle Google Play Integrity spoofing [2/2]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -586,4 +586,8 @@
     <string name="lockscreen_clock_colored_title">Colored clock</string>
     <string name="lockscreen_clock_colored_summary_on">Clock color is affected by monet</string>
     <string name="lockscreen_clock_colored_summary_off">Clock color is always black or white</string>
+
+    <!-- Google Play Integrity Spoof -->
+    <string name="play_integrity_spoof_title">Google Play Integrity spoof</string>
+    <string name="play_integrity_spoof_summary">Spoof your device as different model for Google Play Integrity</string>
 </resources>

--- a/res/xml/general_tweaks.xml
+++ b/res/xml/general_tweaks.xml
@@ -32,6 +32,12 @@
             android:summary="@string/use_photos_spoof_summary"
             android:defaultValue="true" />
 
+        <org.derpfest.support.preferences.SystemPropertySwitchPreference
+            android:key="persist.sys.pixelprops.integrity"
+            android:title="@string/play_integrity_spoof_title"
+            android:summary="@string/play_integrity_spoof_summary"
+            android:defaultValue="true" />
+
         <SwitchPreferenceCompat
             android:key="use_netflix_spoof"
             android:title="@string/netflix_spoof_title"

--- a/src/org/derpfest/derpspace/fragments/GeneralTweaks.java
+++ b/src/org/derpfest/derpspace/fragments/GeneralTweaks.java
@@ -64,6 +64,7 @@ public class GeneralTweaks extends SettingsPreferenceFragment implements OnPrefe
     private static final String KEY_NETFLIX_SPOOF = "use_netflix_spoof";
     private static final String SYS_PHOTOS_SPOOF = "persist.sys.pixelprops.gphotos";
     private static final String SYS_NETFLIX_SPOOF = "persist.sys.pixelprops.netflix";
+    private static final String SYS_INTEGRITY_SPOOF = "persist.sys.pixelprops.integrity";
 
     private SwitchPreferenceCompat mPhotosSpoof;
     private SwitchPreferenceCompat mNetFlixSpoof;


### PR DESCRIPTION
I already confirmed that this commit allows ROMs to use third-party modules bypass DEVICE_INTEGRITY instead of staying at BASIC_INTEGRITY when the fingerprint key expires.

Currently, we have **hardcoded** the fingerprint key used for device integrity checks by GMS into framework_base. This approach means that updating our fingerprint key **requires repeatedly updating framework_base**. In other words, outdated ROMs will only be able to achieve **BASIC_INTEGRITY**, even if the ROM's fingerprint key is capable of achieving DEVICE_INTEGRITY. Some ROMs solutions address this issue by converting the hardcoded content in spoofBuildGms into an overlay, but it's clear that we haven't adopted that commit at this stage.

If you have any objections to this commit or what I’ve mentioned above, you’re right—I don't want to create unnecessary conflicts over this matter.